### PR TITLE
adds lessLoaderOptions option for flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ and then pass it to `less-loader` using `additionalData`:
 const withLess = require("next-with-less");
 const path = require("path");
 
-const pathToLessFileWithVariables = path.resolve('your-file-with-antd-variables.less')
+const pathToLessFileWithVariables = path.resolve("your-file-with-antd-variables.less")
 
 module.exports = withLess({
   future: {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ module.exports = withLess({
 });
 ```
 
+You can see all the options available to `less-loader` [here](https://webpack.js.org/loaders/less-loader/#options).
+
 ### Usage with [`next-compose-plugins`](https://github.com/cyrilwanner/next-compose-plugins)
 
 ```js
@@ -85,6 +87,32 @@ module.exports = withLess({
         /* ... */
       },
     },
+  },
+});
+```
+
+As an alternative, the same can be achieved using the `additionalData` option. 
+Put your variables in a file, like:
+```less
+@primary-color: #9900FF;
+@border-radius-base: 2px;
+```
+and then pass it to `less-loader` using `additionalData`: 
+```js
+// next.config.js
+const withLess = require("next-with-less");
+const path = require("path");
+
+const pathToLessFileWithVariables = path.resolve('your-file-with-antd-variables.less')
+
+module.exports = withLess({
+  future: {
+    webpack5: true,
+  },
+
+  lessLoaderOptions: {
+    /* ... */
+    additionalData: content =>`${content}\n\n@import '${pathToLessFileWithVariables}';`,
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports = withLess({
     webpack5: true,
   },
 
-  lessOptions: {
+  lessLoaderOptions: {
     /* ... */
   },
 });
@@ -49,7 +49,7 @@ const withLess = require("next-with-less");
 const plugins = [
   withLess,
   {
-    lessOptions: {
+    lessLoaderOptions: {
       /* ... */
     },
   },
@@ -58,6 +58,33 @@ const plugins = [
 module.exports = withPlugins(plugins, {
   future: {
     webpack5: true,
+  },
+});
+```
+
+### Customize `antd` theme
+
+To override some of `antd` [default variables](https://ant.design/docs/react/customize-theme), just add them under `lessLoaderOptions.lessOptions.modifyVars`:
+
+```js
+// next.config.js
+const withLess = require("next-with-less");
+
+module.exports = withLess({
+  future: {
+    webpack5: true,
+  },
+
+  lessLoaderOptions: {
+    /* ... */
+    lessOptions: {
+      /* ... */
+      modifyVars: {
+        'primary-color': '#9900FF',
+        'border-radius-base': '2px',
+        /* ... */
+      },
+    },
   },
 });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-with-less",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Next.js + Less CSS Support",
   "main": "index.js",
   "repository": "https://github.com/elado/next-with-less",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const cloneDeep = require("clone-deep");
 // it mimics the exact behavior of CSS extraction/modules/client/server of SASS
 // tested on next 10.1.3 with webpack5
 
-function withLess({ lessOptions, ...nextConfig }) {
+function withLess({ lessLoaderOptions = {}, ...nextConfig }) {
   return Object.assign({}, nextConfig, {
     webpack(config, opts) {
       // there are 2 relevant sass rules in next.js - css modules and global css
@@ -46,9 +46,10 @@ function withLess({ lessOptions, ...nextConfig }) {
       const lessLoader = {
         loader: "less-loader",
         options: {
+          ...lessLoaderOptions,
           lessOptions: {
             javascriptEnabled: true,
-            ...lessOptions,
+            ...lessLoaderOptions.lessOptions,
           },
         },
       };


### PR DESCRIPTION
This PR allows users to provide an `lessLoaderOptions` option, which corresponds to the `options` passed to `less-loader`. This gives users a greater level of flexibility.

Also, added an example to the `README` of how to override `antd` variables.
