### PR TITLE
Clarify usage with next-compose-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ const withPlugins = require("next-compose-plugins");
 const withLess = require("next-with-less");
 
 const plugins = [
-  withLess,
-  {
+  /* ...other plugins... */
+  [withLess, {
     lessLoaderOptions: {
       /* ... */
     },
-  },
+  }],
+  /* ...other plugins... */
 ];
 
 module.exports = withPlugins(plugins, {


### PR DESCRIPTION
I noticed that the configuration example is a little unclear when integrating into a Next.js project that uses `next-compose-plugins`.