### PR TITLE
Next 12 Compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ function withLess({ lessLoaderOptions = {}, ...nextConfig }) {
       let sassGlobalRule;
 
       const cssRule = config.module.rules.find(
-        (rule) => rule.oneOf?.[0]?.options?.__next_css_remove
+        (rule) => rule.oneOf?.find(r => r?.options?.__next_css_remove)
       );
 
       const addLessToRuleTest = (test) => {


### PR DESCRIPTION
The order of these rules is different (`3` instead of `0`) in next 12. This should allow for either version.