### PR TITLE
fix: css loader options editable (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ module.exports = withLess({
   lessLoaderOptions: {
     /* ... */
   },
+  cssLoaderOptions: {
+    mode: 'pure',
+    /* ... */
+  }
 });
 ```
 
-You can see all the options available to `less-loader` [here](https://webpack.js.org/loaders/less-loader/#options).
+You can see all the options available to `less-loader` [here](https://webpack.js.org/loaders/less-loader/#options), and you can see all the options available to `cssLoaderOptions` [here](https://github.com/webpack-contrib/css-loader#modules).
 
 ### Usage with [`next-compose-plugins`](https://github.com/cyrilwanner/next-compose-plugins)
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function patchNextCSSWithLess(
 
 patchNextCSSWithLess();
 
-function withLess({ lessLoaderOptions = {}, ...nextConfig }) {
+function withLess({ lessLoaderOptions = {}, cssLoaderOptions = {}, ...nextConfig }) {
   return Object.assign({}, nextConfig, {
     /**
      * @param {import('webpack').Configuration} config
@@ -73,6 +73,21 @@ function withLess({ lessLoaderOptions = {}, ...nextConfig }) {
           sassModuleRule = rule;
         } else if (rule.test?.source === "(?<!\\.module)\\.(scss|sass)$") {
           sassGlobalRule = rule;
+        } 
+        
+        if(Array.isArray(rule.use)) {
+          rule.use.forEach(moduleLoader => {
+            if(
+              moduleLoader.loader &&
+              moduleLoader.loader.includes('css-loader') &&
+              typeof moduleLoader.options?.modules === 'object'
+            ) {
+              moduleLoader.options.modules = {
+                ...moduleLoader.options.modules,
+                ...cssLoaderOptions
+              }
+            }
+          })
         }
       });
 


### PR DESCRIPTION
Make css loader options editable, such as `mode: 'pure'` to `mode: 'local'`