### PR TITLE
Update injection of less regexp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,10 @@ function patchNextCSSWithLess(
   // overrides https://github.com/vercel/next.js/blob/e8a9bd19967c9f78575faa7d38e90a1270ffa519/packages/next/build/webpack/config/blocks/css/index.ts#L17
   // so https://github.com/vercel/next.js/blob/e8a9bd19967c9f78575faa7d38e90a1270ffa519/packages/next/build/webpack-config.ts#L54
   // has less extension as well
-  nextCSSModule.regexLikeCss = addLessToRegExp(nextCSSModule.regexLikeCss);
+  nextCSSModule = {
+    ...nextCSSModule,
+    regexLikeCss: addLessToRegExp(nextCSSModule.regexLikeCss)
+  }
 }
 
 patchNextCSSWithLess();


### PR DESCRIPTION
Update injection of less regexp tp work in Next@13.3+ Since they changed the way it works, you need to extend the object insted just replacing the value,